### PR TITLE
✨ Improve scrolling experience on iOS

### DIFF
--- a/app/screens/content-view-screen/content-view-screen.tsx
+++ b/app/screens/content-view-screen/content-view-screen.tsx
@@ -68,6 +68,7 @@ export class ContentViewScreen extends React.Component<ContentViewScreenProps, {
           style={FULL}
           sharedCookiesEnabled={true}
           source={{ uri: content.url }}
+          decelerationRate={0.998}
           // TODO: remove HACK after applicationNameForUserAgent type is fixed
           {...{ applicationNameForUserAgent: COMMON_API_CONFIG.userAgent }}
         />


### PR DESCRIPTION
Improve user experience of scrolling, when reading content in WebView on iOS. 

The default value gives too much friction. See `react-native-webview` documentation for [decelerationRate](https://github.com/react-native-community/react-native-webview/blob/master/docs/Reference.md#decelerationrate).