### PR TITLE
⚡️ Change liker land user api to min version

### DIFF
--- a/app/models/user-store/user-store.ts
+++ b/app/models/user-store/user-store.ts
@@ -218,7 +218,7 @@ export const UserStoreModel = types
       const result: UserResult = yield self.env.likerLandAPI.fetchCurrentUserInfo(opts)
       switch (result.kind) {
         case "ok":
-          self.updateUserFromResultData(result.data)
+          // Do nothing, store like.co user instead of liker.land
           break
 
         case "unauthorized":

--- a/app/services/api/likerland-api.ts
+++ b/app/services/api/likerland-api.ts
@@ -67,7 +67,7 @@ export class LikerLandAPI {
    * Fetch the current user info
    */
   async fetchCurrentUserInfo(opts: Types.APIOptions = {}): Promise<Types.UserResult> {
-    const response: ApiResponse<any> = await this.apisauce.get("/users/self")
+    const response: ApiResponse<any> = await this.apisauce.get("/users/self/min")
 
     if (!response.ok) {
       const problem = getGeneralApiProblem(response)


### PR DESCRIPTION
Current liker.land api includes unused data like civic and superlike status, which we fetch separately in app
I have made a new api that only returns user login status which should improve api speed