### PR TITLE
Fix liker.land OAuth verification & other minor issues

### DIFF
--- a/app/models/chain-store/chain-store.ts
+++ b/app/models/chain-store/chain-store.ts
@@ -220,6 +220,9 @@ export const ChainStoreModel = types
       if (!address) {
         throw Error("MISSING_WALLET_ADDRESS")
       }
+      if (typeof address !== "string") {
+        throw Error("INVALID_WALLET_ADDRESS")
+      }
       let wallet = self.wallets.get(address)
       if (!wallet) {
         wallet = WalletModel.create({ address })

--- a/app/models/content/content.ts
+++ b/app/models/content/content.ts
@@ -108,6 +108,7 @@ export const ContentModel = types
       }
     }),
     fetchLikeStat: flow(function * () {
+      if (!self.creator) return
       self.isFetchingLikeStats = true
       try {
         const result: LikeStatResult = yield self.env.likeCoAPI.fetchContentLikeStat(

--- a/app/models/environment.ts
+++ b/app/models/environment.ts
@@ -30,6 +30,7 @@ export class Environment {
     await this.appConfig.setup()
     await this.branchIO.setup()
     const {
+      AUTHCORE_ROOT_URL,
       COSMOS_LCD_URL,
       COSMOS_CHAIN_ID,
       LIKECO_API_URL,
@@ -37,6 +38,7 @@ export class Environment {
       BIG_DIPPER_URL,
       SENTRY_DSN,
     } = this.appConfig.getAllParams()
+    this.authCoreAPI.setup(AUTHCORE_ROOT_URL, COSMOS_CHAIN_ID)
     this.likeCoAPI.setup(LIKECO_API_URL)
     this.likerLandAPI.setup(LIKERLAND_API_URL)
     this.cosmosAPI.setup(COSMOS_LCD_URL, COSMOS_CHAIN_ID)
@@ -44,14 +46,6 @@ export class Environment {
     if (SENTRY_DSN) {
       initSentry(SENTRY_DSN)
     }
-  }
-
-  setupAuthCore() {
-    const {
-      COSMOS_CHAIN_ID,
-      AUTHCORE_ROOT_URL,
-    } = this.appConfig.getAllParams()
-    this.authCoreAPI.setup(AUTHCORE_ROOT_URL, COSMOS_CHAIN_ID)
   }
 
   /**

--- a/app/models/root-store/setup-root-store.ts
+++ b/app/models/root-store/setup-root-store.ts
@@ -89,8 +89,6 @@ export async function setupRootStore() {
     data = await storage.load(ROOT_STATE_STORAGE_KEY) || {}
     rootStore = createRootStore(env, data)
 
-    // Setup Authcore
-    env.setupAuthCore()
     if (rootStore.userStore.currentUser) {
       rootStore.userStore.authCore.resume().then(() => {
         const address = rootStore.userStore.authCore.primaryCosmosAddress
@@ -104,7 +102,6 @@ export async function setupRootStore() {
     logError(e.message)
 
     rootStore = createRootStore(env)
-    env.setupAuthCore()
   }
 
   // reactotron logging

--- a/app/screens/content-view-screen/content-view-screen.tsx
+++ b/app/screens/content-view-screen/content-view-screen.tsx
@@ -32,7 +32,9 @@ export class ContentViewScreen extends React.Component<ContentViewScreenProps, {
   componentWillUnmount() {
     // Update like count incase user has liked the content
     const { content } = this.props.navigation.state.params
-    content.fetchLikeStat()
+    if (content.shouldFetchLikeStat) {
+      content.fetchLikeStat()
+    }
   }
 
   private goBack = () => {

--- a/app/screens/likerland-oauth-screen/likerland-oauth-screen.tsx
+++ b/app/screens/likerland-oauth-screen/likerland-oauth-screen.tsx
@@ -101,10 +101,10 @@ export class LikerLandOAuthScreen extends React.Component<LikerLandOAuthScreenPr
   private verifySignIn = async () => {
     if (this.hasHandledRedirect || this.isVerifyingSignIn) return
     this.isVerifyingSignIn = true
-    await this.props.rootStore.userStore.fetchLikerLandUserInfo({ isSlient: true })
+    const response = await this.props.rootStore.env.likerLandAPI.fetchCurrentUserInfo({ isSlient: true })
     this.isVerifyingSignIn = false
     if (this.hasHandledRedirect) return
-    if (this.props.rootStore.userStore.currentUser) {
+    if (response.kind === "ok") {
       this.handlePostSignIn()
     } else if (this.verifySignInRetryCount < this.maxVerifySignInRetryCount) {
       this.verifySignInRetryCount += 1


### PR DESCRIPTION
Since the `fetchLikerLandUserInfo()` do nothing after returning success, the verification should not depend on `currentUser`, should check the response status instead