### PR TITLE
⚡️ Make wallet init async with authcore user init

### DIFF
--- a/app/services/authcore/authcore.ts
+++ b/app/services/authcore/authcore.ts
@@ -116,12 +116,17 @@ export class AuthCoreAPI {
     if (!accessToken) {
       return {
         accessToken: "",
-        addresses: [],
       }
     }
 
     this.client.auth.client.bearer = `Bearer ${accessToken}`
 
+    return {
+      accessToken,
+    }
+  }
+
+  async setupWallet(accessToken: string) {
     __DEV__ && console.tron.log("Initializing AuthCore Key Vault Client")
     this.keyVaultClient = await new AuthcoreVaultClient({
       apiBaseURL: this.baseURL,
@@ -136,7 +141,6 @@ export class AuthCoreAPI {
     // Getting Cosmos addresses, it will be created if not exists
     const addresses = await this.getCosmosAddresses()
     return {
-      accessToken,
       addresses,
     }
   }
@@ -173,6 +177,7 @@ export class AuthCoreAPI {
 
   async cosmosSign(payload: Record<string, any>, address: string) {
     let signed
+    if (!this.cosmosProvider) throw new Error('WALLET_NOT_INITED');
     try {
       signed = await this.cosmosProvider.sign(payload, address)
     } catch (error) {


### PR DESCRIPTION
Old code makes authcore token refresh -> kv client init -> cosmos init -> authcore user fecth a single thread process.
This PR attempt to separate authcore use fetch from kv client/secretd operation to improve app resume speed