### PR TITLE
🚸 Verbose auth and duplicate error message in add to bookmark

### DIFF
--- a/app/i18n/translations/en.json
+++ b/app/i18n/translations/en.json
@@ -156,8 +156,9 @@
   "SaveToBookmarkScreen": {
     "DismissButtonText": "Click to close",
     "Error": {
-      "forbidden": "Please sign-in again in the app.",
+      "unauthorized": "Please sign-in again in the app.",
       "invalid-url": "Cannot save this link.",
+      "conflict": "The link already exist",
       "unknown": "Unable to save to Liker Land."
     }
   },

--- a/app/i18n/translations/zh-Hans-CN.json
+++ b/app/i18n/translations/zh-Hans-CN.json
@@ -155,8 +155,9 @@
   "SaveToBookmarkScreen": {
     "DismissButtonText": "按此关闭",
     "Error": {
-      "forbidden": "请重新登入 Liker Land。",
+      "unauthorized": "请重新登入 Liker Land。",
       "invalid-url": "未能成功辨识链接。",
+      "conflict": "阅读列表内已存有此网页",
       "unknown": "未能成功把网页加到 Liker Land 阅读列表。"
     }
   },

--- a/app/i18n/translations/zh-Hant-HK.json
+++ b/app/i18n/translations/zh-Hant-HK.json
@@ -155,8 +155,9 @@
   "SaveToBookmarkScreen": {
     "DismissButtonText": "按此關閉",
     "Error": {
-      "forbidden": "請重新登入 Liker Land。",
+      "unauthorized": "請重新登入 Liker Land。",
       "invalid-url": "未能成功辨識鏈接。",
+      "conflict": "閱讀列表內已存有此網頁",
       "unknown": "未能成功把網頁加到 Liker Land 閱讀列表。"
     }
   },

--- a/app/i18n/translations/zh-Hant-TW.json
+++ b/app/i18n/translations/zh-Hant-TW.json
@@ -155,8 +155,9 @@
   "SaveToBookmarkScreen": {
     "DismissButtonText": "按此關閉",
     "Error": {
-      "forbidden": "請重新登入 Liker Land。",
+      "unauthorized": "請重新登入 Liker Land。",
       "invalid-url": "未能成功辨識鏈接。",
+      "conflict": "閱讀列表內已存有此網頁",
       "unknown": "未能成功把網頁加到 Liker Land 閱讀列表。"
     }
   },

--- a/app/services/api/api-problem.ts
+++ b/app/services/api/api-problem.ts
@@ -26,6 +26,10 @@ export type GeneralApiProblem =
    */
   | { kind: "not-found" }
   /**
+   * Conlict states between client and server. This is a 409.
+   */
+  | { kind: "conflict" }
+  /**
    * All other 4xx series errors.
    */
   | { kind: "rejected", data?: any }
@@ -65,6 +69,8 @@ export function getGeneralApiProblem(response: ApiResponse<any>): GeneralApiProb
           return { kind: "forbidden" }
         case 404:
           return { kind: "not-found" }
+        case 409:
+          return { kind: "conflict" }
         default:
           return { kind: "rejected", data: response.data }
       }


### PR DESCRIPTION
API should return 401 on auth and 409 on duplicate bookmark
Currently it returns 500 on duplicate, [PR](https://github.com/likecoin/liker-land/pull/299) pending for the latter behaviour