### PR TITLE
🔨 Fix missing Sentry params for build

### DIFF
--- a/.env
+++ b/.env
@@ -49,6 +49,8 @@ APP_REFERRAL_ENABLE=
 
 SENTRY_DSN=
 SENTRY_ENV=development
+SENTRY_ORG=likecoin-foundation
+SENTRY_PROJECT=likerland-app-dev
 
 SIGNIN_SCREEN_BGIMAGE_URL=
 

--- a/.github/workflows/production_build.yaml
+++ b/.github/workflows/production_build.yaml
@@ -55,6 +55,7 @@ jobs:
       run: bundle exec fastlane ci_beta
       working-directory: ios
       env:
+        SENTRY_LOAD_DOTENV: 0
         FASTLANE_PASSWORD: ${{ secrets.FASTLANE_APPLE_PASSWORD }}
         APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
   build-android:
@@ -114,5 +115,6 @@ jobs:
       run: bundle exec fastlane beta
       working-directory: android
       env:
+        SENTRY_LOAD_DOTENV: 0
         ANDROID_RELEASE_KEY_STORE_PASSWORD: ${{ secrets.ANDROID_RELEASE_KEY_STORE_PASSWORD }}
         ANDROID_RELEASE_KEY_KEY_PASSWORD: ${{  secrets.ANDROID_RELEASE_KEY_KEY_PASSWORD }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -118,6 +118,7 @@ jobs:
       run: bundle exec fastlane apk
       working-directory: android
       env:
+        SENTRY_LOAD_DOTENV: 0
         ANDROID_RELEASE_KEY_STORE_PASSWORD: ${{ secrets.ANDROID_RELEASE_KEY_STORE_PASSWORD }}
         ANDROID_RELEASE_KEY_KEY_PASSWORD: ${{  secrets.ANDROID_RELEASE_KEY_KEY_PASSWORD }}
     - name: Format release url


### PR DESCRIPTION
Set required config in .env and override with `SENTRY_LOAD_DOTENV=0`, allowing CI to read config from `sentry.properties`