### PR TITLE
🚸 Add loading hint & init timeout

### DIFF
--- a/.env
+++ b/.env
@@ -4,6 +4,8 @@
 # Then just do this to import them:
 # import { API_URL } from 'react-native-dotenv'
 
+INIT_APP_TIMEOUT=10000
+
 # The key we'll be saving our state as within async storage.
 ROOT_STATE_STORAGE_KEY=root
 

--- a/app/components/loading-screen/loading-screen.tsx
+++ b/app/components/loading-screen/loading-screen.tsx
@@ -22,6 +22,11 @@ export interface LoadingScreenProps {
   text?: string
 
   /**
+   * Text which is looked up via i18n.
+   */
+  tx?: string
+
+  /**
    * An optional style override useful for padding & margin.
    */
   style?: StyleProp<ViewStyle>
@@ -31,7 +36,7 @@ export interface LoadingScreenProps {
  * A loading screen.
  */
 export function LoadingScreen(props: LoadingScreenProps) {
-  const { style, ...restProps } = props
+  const { style, tx, text, ...restProps } = props
   const rootStyle = StyleSheet.flatten([Style.Screen, style])
   return (
     <Screen
@@ -42,7 +47,8 @@ export function LoadingScreen(props: LoadingScreenProps) {
     >
       <LoadingLikeCoin style={Style.Animation} />
       <Text
-        text={props.text}
+        tx={tx}
+        text={text}
         size="default"
         color="lightCyan"
         align="center"

--- a/app/i18n/translations/en.json
+++ b/app/i18n/translations/en.json
@@ -1,4 +1,10 @@
 {
+  "closeApp": "Close App",
+  "initializing": "Initializing",
+  "initializingFailedAlertTitle": "Initialization Failed",
+  "initializingFailedAlertMessage": "Please restart the App",
+  "signingIn": "Signing in",
+  "signingOut": "Signing out",
   "AppRatingPrompt": {
     "Title": "Are you satisfied with Liker Land?",
     "DenialTitle": "Can you give us some feedback?"

--- a/app/i18n/translations/zh-Hans-CN.json
+++ b/app/i18n/translations/zh-Hans-CN.json
@@ -1,4 +1,10 @@
 {
+  "closeApp": "结束 App",
+  "initializing": "初始化中",
+  "initializingFailedAlertTitle": "初始化失败",
+  "initializingFailedAlertMessage": "请重新启动 App",
+  "signingIn": "登录中",
+  "signingOut": "登出中",
   "AppRatingPrompt": {
     "Title": "你满意 Liker Land 吗?",
     "DenialTitle": "可否给我们一些改善建议?"

--- a/app/i18n/translations/zh-Hant-HK.json
+++ b/app/i18n/translations/zh-Hant-HK.json
@@ -1,9 +1,9 @@
 {
-  "closeApp": "結束 App",
+  "closeApp": "關閉 App",
   "initializing": "初始化中",
   "initializingFailedAlertTitle": "初始化失敗",
   "initializingFailedAlertMessage": "請重新啟動 App",
-  "signingIn": "登錄中",
+  "signingIn": "登入中",
   "signingOut": "登出中",
   "AppRatingPrompt": {
     "Title": "你滿意 Liker Land 嗎?",

--- a/app/i18n/translations/zh-Hant-HK.json
+++ b/app/i18n/translations/zh-Hant-HK.json
@@ -1,8 +1,8 @@
 {
   "closeApp": "關閉 App",
-  "initializing": "初始化中",
-  "initializingFailedAlertTitle": "初始化失敗",
-  "initializingFailedAlertMessage": "請重新啟動 App",
+  "initializing": "啟動中",
+  "initializingFailedAlertTitle": "啟動失敗",
+  "initializingFailedAlertMessage": "請重新開啟 App",
   "signingIn": "登入中",
   "signingOut": "登出中",
   "AppRatingPrompt": {

--- a/app/i18n/translations/zh-Hant-HK.json
+++ b/app/i18n/translations/zh-Hant-HK.json
@@ -1,4 +1,10 @@
 {
+  "closeApp": "結束 App",
+  "initializing": "初始化中",
+  "initializingFailedAlertTitle": "初始化失敗",
+  "initializingFailedAlertMessage": "請重新啟動 App",
+  "signingIn": "登錄中",
+  "signingOut": "登出中",
   "AppRatingPrompt": {
     "Title": "你滿意 Liker Land 嗎?",
     "DenialTitle": "可否給我們一些改善建議?"

--- a/app/i18n/translations/zh-Hant-TW.json
+++ b/app/i18n/translations/zh-Hant-TW.json
@@ -1,9 +1,9 @@
 {
-  "closeApp": "結束 App",
+  "closeApp": "關閉 App",
   "initializing": "初始化中",
   "initializingFailedAlertTitle": "初始化失敗",
   "initializingFailedAlertMessage": "請重新啟動 App",
-  "signingIn": "登錄中",
+  "signingIn": "登入中",
   "signingOut": "登出中",
   "AppRatingPrompt": {
     "Title": "您是否滿意 Liker Land？",

--- a/app/i18n/translations/zh-Hant-TW.json
+++ b/app/i18n/translations/zh-Hant-TW.json
@@ -1,6 +1,6 @@
 {
   "closeApp": "關閉 App",
-  "initializing": "初始化中",
+  "initializing": "起動中",
   "initializingFailedAlertTitle": "初始化失敗",
   "initializingFailedAlertMessage": "請重新啟動 App",
   "signingIn": "登入中",

--- a/app/i18n/translations/zh-Hant-TW.json
+++ b/app/i18n/translations/zh-Hant-TW.json
@@ -1,4 +1,10 @@
 {
+  "closeApp": "結束 App",
+  "initializing": "初始化中",
+  "initializingFailedAlertTitle": "初始化失敗",
+  "initializingFailedAlertMessage": "請重新啟動 App",
+  "signingIn": "登錄中",
+  "signingOut": "登出中",
   "AppRatingPrompt": {
     "Title": "您是否滿意 Liker Land？",
     "DenialTitle": "是否願意給予我們一些改善建議？"

--- a/app/i18n/translations/zh-Hant-TW.json
+++ b/app/i18n/translations/zh-Hant-TW.json
@@ -1,8 +1,8 @@
 {
   "closeApp": "關閉 App",
-  "initializing": "起動中",
-  "initializingFailedAlertTitle": "初始化失敗",
-  "initializingFailedAlertMessage": "請重新啟動 App",
+  "initializing": "啟動中",
+  "initializingFailedAlertTitle": "啟動失敗",
+  "initializingFailedAlertMessage": "請重新開啟 App",
   "signingIn": "登入中",
   "signingOut": "登出中",
   "AppRatingPrompt": {

--- a/app/screens/auth-loading-screen/auth-loading-screen.tsx
+++ b/app/screens/auth-loading-screen/auth-loading-screen.tsx
@@ -108,7 +108,7 @@ export class AuthLoadingScreen extends React.Component<AuthLoadingScreenProps, {
 
   render() {
     return (
-      <LoadingScreen />
+      <LoadingScreen tx="signingIn" />
     )
   }
 }

--- a/app/screens/sign-in-screen/sign-in-screen.tsx
+++ b/app/screens/sign-in-screen/sign-in-screen.tsx
@@ -224,7 +224,7 @@ export class SignInScreen extends React.Component<SignInScreenProps, SignInScree
     } = this.props
 
     if (isSigningOut) {
-      return <LoadingScreen />
+      return <LoadingScreen tx="signingOut" />
     }
 
     const isLoading = !!isSigningIn || hasSignedInToAuthcore

--- a/app/utils/error.ts
+++ b/app/utils/error.ts
@@ -1,7 +1,7 @@
 import { sentryCaptureError, sentryCaptureMessage } from './sentry'
 
 export function logError(err: any) {
-  if (__DEV__) {
+  if (__DEV__ && console.tron) {
     console.tron.error(err.message || err, null)
   } else {
     console.error(err)
@@ -10,7 +10,7 @@ export function logError(err: any) {
 }
 
 export function logMessage(msg: string) {
-  if (__DEV__) {
+  if (__DEV__ && console.tron) {
     console.tron.warn(msg)
   } else {
     console.warn(msg)


### PR DESCRIPTION
- Guard possible errors when init `rootStore` failed
- Added hint text in loading screen to pinpointing error for CS
- Alert user to restart the app if init `rootStore` takes longer than usual