### PR TITLE
✨ Improve navigation experience on iOS

### DIFF
--- a/app/navigation/app-navigator.tsx
+++ b/app/navigation/app-navigator.tsx
@@ -66,7 +66,6 @@ export const AppNavigator = createStackNavigator({
   Transfer: TransferNavigator,
   WalletConnect: WalletConnectRequestScreen,
 }, {
-  mode: "modal",
   headerMode: "none",
   initialRouteName: "Main",
 })

--- a/app/screens/content-view-screen/content-view-screen.tsx
+++ b/app/screens/content-view-screen/content-view-screen.tsx
@@ -339,7 +339,7 @@ export class ContentViewScreen extends React.Component<ContentViewScreenProps, {
             <StatusBar barStyle="light-content" />
             <Header
               headerText={content?.normalizedTitle}
-              leftIcon="close"
+              leftIcon="back"
               onLeftPress={this.goBack}
             />
           </SafeAreaView>

--- a/app/screens/crisp-support-screen/crisp-support-screen.tsx
+++ b/app/screens/crisp-support-screen/crisp-support-screen.tsx
@@ -34,7 +34,7 @@ export class CrispSupportScreen extends React.Component<CrispSupportScreenProps,
         style={FULL}
       >
         <Header
-          leftIcon="close"
+          leftIcon="back"
           onLeftPress={this.goBack}
         />
         <WebView

--- a/app/screens/wallet-dashboard-screen/wallet-dashboard-screen.tsx
+++ b/app/screens/wallet-dashboard-screen/wallet-dashboard-screen.tsx
@@ -102,7 +102,7 @@ export class WalletDashboardScreen extends React.Component<Props> {
         >
           <View>
             <Header
-              leftIcon="close"
+              leftIcon="back"
               leftIconColor="white"
               onLeftPress={this.onPressCloseButton}
             >


### PR DESCRIPTION
So iOS app users can swipe on the edge of screen to go back, specifically, on reader-screen (Super Like).

I have tested on iOS simulator, but failed to launch the app on Android, for various configuration errors. However, the change is expected to have no impact on Android app experience.